### PR TITLE
Fix #5: Use absl.flags instead of gflags.

### DIFF
--- a/deepq_mineral_shards.py
+++ b/deepq_mineral_shards.py
@@ -5,6 +5,8 @@ import tempfile
 import tensorflow as tf
 import zipfile
 
+from absl import flags
+
 import baselines.common.tf_util as U
 
 from baselines import logger
@@ -16,8 +18,6 @@ from pysc2.lib import actions as sc2_actions
 from pysc2.env import environment
 from pysc2.lib import features
 from pysc2.lib import actions
-
-import gflags as flags
 
 _PLAYER_RELATIVE = features.SCREEN_FEATURES.player_relative.index
 _PLAYER_FRIENDLY = 1

--- a/defeat_zerglings/dqfd.py
+++ b/defeat_zerglings/dqfd.py
@@ -5,6 +5,8 @@ import tempfile
 import tensorflow as tf
 import zipfile
 
+from absl import flags
+
 import baselines.common.tf_util as U
 
 from baselines import logger
@@ -18,8 +20,6 @@ from pysc2.lib import features
 from pysc2.lib import actions
 
 from defeat_zerglings import common
-
-import gflags as flags
 
 _PLAYER_RELATIVE = features.SCREEN_FEATURES.player_relative.index
 

--- a/defeat_zerglings/run_demo_agent.py
+++ b/defeat_zerglings/run_demo_agent.py
@@ -1,6 +1,6 @@
 import sys
 
-import gflags as flags
+from absl import flags
 from baselines import deepq
 from pysc2.env import sc2_env
 from pysc2.lib import actions

--- a/enjoy_mineral_shards.py
+++ b/enjoy_mineral_shards.py
@@ -1,7 +1,7 @@
 import sys
 
+from absl import flags
 import baselines.common.tf_util as U
-import gflags as flags
 import numpy as np
 from baselines import deepq
 from pysc2.env import environment

--- a/mineral/run_scripted_agent.py
+++ b/mineral/run_scripted_agent.py
@@ -1,6 +1,6 @@
 import sys
 
-import gflags as flags
+from absl import flags
 from baselines import deepq
 from pysc2.env import sc2_env
 from pysc2.lib import actions

--- a/tests/scripted_test.py
+++ b/tests/scripted_test.py
@@ -11,22 +11,18 @@ from pysc2.tests import utils
 from pysc2.lib import actions as sc2_actions
 from pysc2.lib import features
 
-from pysc2.lib import basetest
-import gflags as flags
+from absl import flags
+from absl.testing import absltest
 import sys
 
 _NO_OP = sc2_actions.FUNCTIONS.no_op.id
 _PLAYER_RELATIVE = features.SCREEN_FEATURES.player_relative.index
-
-FLAGS = flags.FLAGS
 
 class TestScripted(utils.TestCase):
   steps = 2000
   step_mul = 1
 
   def test_defeat_zerglings(self):
-    FLAGS(sys.argv)
-
     with sc2_env.SC2Env(
         "DefeatZerglingsAndBanelings",
         step_mul=self.step_mul,
@@ -44,4 +40,4 @@ class TestScripted(utils.TestCase):
     self.assertEqual(agent.steps, self.steps)
 
 if __name__ == "__main__":
-  basetest.main()
+  absltest.main()

--- a/train_defeat_zerglings.py
+++ b/train_defeat_zerglings.py
@@ -2,7 +2,7 @@ import sys
 import os
 import datetime
 
-import gflags as flags
+from absl import flags
 from baselines import deepq
 from pysc2.env import sc2_env
 from pysc2.lib import actions

--- a/train_mineral_shards.py
+++ b/train_mineral_shards.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-import gflags as flags
+from absl import flags
 from baselines import deepq
 from pysc2.env import sc2_env
 from pysc2.lib import actions


### PR DESCRIPTION
Fixes #5.

Since pysc2 switched from python-gflags to absl, using python-gflags here no longer works.

pysc2 also removed pysc2.lib.basetest.

See https://github.com/deepmind/pysc2/commit/f2f96c08c32ea92fa60485cc6d7307bc17c1c6db